### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,5 +1,7 @@
 # .github/workflows/dependency-check.yml
 name: Maven Dependency Check
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:  # manually triggerable


### PR DESCRIPTION
Potential fix for [https://github.com/gkrost/maven-gitlog-plugin/security/code-scanning/7](https://github.com/gkrost/maven-gitlog-plugin/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to read the repository contents (e.g., to check out the source code), we will set `contents: read` as the minimal required permission. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
